### PR TITLE
stagefright: Don't crash on invalid / null AVCC atoms in MKV

### DIFF
--- a/media/libstagefright/MPEG4Extractor.cpp
+++ b/media/libstagefright/MPEG4Extractor.cpp
@@ -3325,11 +3325,13 @@ MPEG4Source::MPEG4Source(
 
         const uint8_t *ptr = (const uint8_t *)data;
 
-        CHECK(size >= 7);
-        CHECK_EQ((unsigned)ptr[0], 1u);  // configurationVersion == 1
-
-        // The number of bytes used to encode the length of a NAL unit.
-        mNALLengthSize = 1 + (ptr[4] & 3);
+        if (size < 7 || ptr[0] != 1) {
+            ALOGE("Invalid AVCC atom, size %zu, configurationVersion: %d",
+                    size, ptr[0]);
+        } else {
+            // The number of bytes used to encode the length of a NAL unit.
+            mNALLengthSize = 1 + (ptr[4] & 3);
+        }
     } else if (mIsHEVC) {
         uint32_t type;
         const void *data;

--- a/media/libstagefright/matroska/MatroskaExtractor.cpp
+++ b/media/libstagefright/matroska/MatroskaExtractor.cpp
@@ -224,18 +224,19 @@ MatroskaSource::MatroskaSource(
     mIsAudio = !strncasecmp("audio/", mime, 6);
 
     if (!strcasecmp(mime, MEDIA_MIMETYPE_VIDEO_AVC)) {
-        mType = AVC;
-
         uint32_t dummy;
         const uint8_t *avcc;
         size_t avccSize;
         CHECK(meta->findData(
                     kKeyAVCC, &dummy, (const void **)&avcc, &avccSize));
 
-        CHECK_GE(avccSize, 5u);
-
-        mNALSizeLen = 1 + (avcc[4] & 3);
-        ALOGV("mNALSizeLen = %zu", mNALSizeLen);
+        if (avccSize < 7) {
+            ALOGW("Invalid AVCC atom in track, size %zu", avccSize);
+        } else {
+            mNALSizeLen = 1 + (avcc[4] & 3);
+            ALOGV("mNALSizeLen = %zu", mNALSizeLen);
+            mType = AVC;
+        }
     } else if (!strcasecmp(mime, MEDIA_MIMETYPE_VIDEO_HEVC)) {
         mType = HEVC;
 


### PR DESCRIPTION
- Seen in the wild. If a file contains an invalid track, skip it.
- Also correct AVCC atom size check in Matroska extractor.

REF: CYNGNOS-2168
Change-Id: I589aadbd689c9a00e1dca613e61fcec5b06ed69a
